### PR TITLE
WEB-188 Implement SET_TRACKING_PROPERTY WebView bridge method

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ getEsimInfo().then(({supportsEsim}) => { ... });
 
 -   `supportsEsim`: true if the device supports eSIM, false otherwise
 
-### setCustomerHash
+### setTrackingProperty
 
 Sets a property related to some specific tracking system
 

--- a/README.md
+++ b/README.md
@@ -674,6 +674,28 @@ getEsimInfo().then(({supportsEsim}) => { ... });
 
 -   `supportsEsim`: true if the device supports eSIM, false otherwise
 
+### setCustomerHash
+
+Sets a property related to some specific tracking system
+
+-   Available for app versions 12.4 and higher
+
+```typescript
+setTrackingProperty: (system: string, name: string, value?: string) => Promise<void>;
+```
+
+-   `system`: Tracking system that will handle the property
+-   `name`: name of the property
+-   `value`: value of the property (nullable)
+
+#### Example
+
+```javascript
+import {setTrackingProperty} from '@tef-novum/webview-bridge';
+
+setTrackingProperty('some_system', 'some_property_name', 'some_property_value');
+```
+
 ## Error handling
 
 If an error occurs, promise will be rejected with an error object:

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -262,7 +262,11 @@ test('set tracking property', async () => {
         }),
     });
 
-    const res = await setTrackingProperty('any_system', 'any_name', 'any_value');
+    const res = await setTrackingProperty(
+        'any_system',
+        'any_name',
+        'any_value',
+    );
 
     expect(res).toBeUndefined();
     removeFakeAndroidPostMessage();

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -5,6 +5,7 @@ import {
     logTiming,
     setCustomerHash,
     getCustomerHash,
+    setTrackingProperty,
 } from '../analytics';
 import {
     createFakeAndroidPostMessage,
@@ -245,4 +246,24 @@ test('get customer hash', async () => {
         expect(res).toMatchObject({hash: 'ANY_HASH'});
         removeFakeAndroidPostMessage();
     });
+});
+
+test('set tracking property', async () => {
+    createFakeAndroidPostMessage({
+        checkMessage: (msg) => {
+            expect(msg.type).toBe('SET_TRACKING_PROPERTY');
+            expect(msg.payload.system).toBe('any_system');
+            expect(msg.payload.name).toBe('any_name');
+            expect(msg.payload.value).toBe('any_value');
+        },
+        getResponse: (msg) => ({
+            type: 'SET_TRACKING_PROPERTY',
+            id: msg.id,
+        }),
+    });
+
+    const res = await setTrackingProperty('any_system', 'any_name', 'any_value');
+
+    expect(res).toBeUndefined();
+    removeFakeAndroidPostMessage();
 });

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -248,11 +248,13 @@ test('get customer hash', async () => {
     });
 });
 
-test('set tracking property', async () => {
+test('set tracking property for palitagem', async () => {
+    const any_system = 'palitagem';
+
     createFakeAndroidPostMessage({
         checkMessage: (msg) => {
             expect(msg.type).toBe('SET_TRACKING_PROPERTY');
-            expect(msg.payload.system).toBe('any_system');
+            expect(msg.payload.system).toBe(any_system);
             expect(msg.payload.name).toBe('any_name');
             expect(msg.payload.value).toBe('any_value');
         },
@@ -262,11 +264,7 @@ test('set tracking property', async () => {
         }),
     });
 
-    const res = await setTrackingProperty(
-        'any_system',
-        'any_name',
-        'any_value',
-    );
+    const res = await setTrackingProperty(any_system, 'any_name', 'any_value');
 
     expect(res).toBeUndefined();
     removeFakeAndroidPostMessage();

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -249,12 +249,12 @@ test('get customer hash', async () => {
 });
 
 test('set tracking property for palitagem', async () => {
-    const any_system = 'palitagem';
+    const anySystem = 'palitagem';
 
     createFakeAndroidPostMessage({
         checkMessage: (msg) => {
             expect(msg.type).toBe('SET_TRACKING_PROPERTY');
-            expect(msg.payload.system).toBe(any_system);
+            expect(msg.payload.system).toBe(anySystem);
             expect(msg.payload.name).toBe('any_name');
             expect(msg.payload.value).toBe('any_value');
         },
@@ -264,7 +264,7 @@ test('set tracking property for palitagem', async () => {
         }),
     });
 
-    const res = await setTrackingProperty(any_system, 'any_name', 'any_value');
+    const res = await setTrackingProperty(anySystem, 'any_name', 'any_value');
 
     expect(res).toBeUndefined();
     removeFakeAndroidPostMessage();

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -353,3 +353,13 @@ export const getCustomerHash = (): Promise<{hash: string}> =>
     postMessageToNativeApp({
         type: 'GET_CUSTOMER_HASH',
     });
+
+export const setTrackingProperty = (system: string, name: string, value?: string): Promise<void> =>
+    postMessageToNativeApp({
+        type: 'SET_TRACKING_PROPERTY',
+        payload: {
+            system: system,
+            name: name,
+            value: value
+        }
+    });

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -366,4 +366,6 @@ export const setTrackingProperty = (
             name: name,
             value: value,
         },
-    }).catch(() => {});
+    }).catch(() => {
+        // do nothing
+    });

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -366,4 +366,4 @@ export const setTrackingProperty = (
             name: name,
             value: value,
         },
-    });
+    }).catch(() => {});

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -354,12 +354,16 @@ export const getCustomerHash = (): Promise<{hash: string}> =>
         type: 'GET_CUSTOMER_HASH',
     });
 
-export const setTrackingProperty = (system: string, name: string, value?: string): Promise<void> =>
+export const setTrackingProperty = (
+    system: string,
+    name: string,
+    value?: string,
+): Promise<void> =>
     postMessageToNativeApp({
         type: 'SET_TRACKING_PROPERTY',
         payload: {
             system: system,
             name: name,
-            value: value
-        }
+            value: value,
+        },
     });

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -355,7 +355,7 @@ export const getCustomerHash = (): Promise<{hash: string}> =>
     });
 
 export const setTrackingProperty = (
-    system: string,
+    system: 'palitagem' | 'medalia',
     name: string,
     value?: string,
 ): Promise<void> =>

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -181,6 +181,11 @@ export type ResponsesFromNativeApp = {
         id: string;
         payload: {supportsEsim: boolean};
     };
+    SET_TRACKING_PROPERTY: {
+        type: 'SET_TRACKING_PROPERTY';
+        id: string;
+        payload: void
+    };
 };
 
 export type NativeAppResponsePayload<

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -184,7 +184,7 @@ export type ResponsesFromNativeApp = {
     SET_TRACKING_PROPERTY: {
         type: 'SET_TRACKING_PROPERTY';
         id: string;
-        payload: void
+        payload: void;
     };
 };
 

--- a/src/webview-bridge-cjs.js.flow
+++ b/src/webview-bridge-cjs.js.flow
@@ -219,5 +219,11 @@ declare export function getDiskSpaceInfo(): Promise<{|
 |}>;
 
 declare export function getEsimInfo(): Promise<{|
-    supportsEsim: boolean;
+    supportsEsim: boolean,
 |}>;
+
+declare export function setTrackingProperty(
+    system: 'palitagem' | 'medalia',
+    name: string,
+    value?: string,
+): Promise<void>;


### PR DESCRIPTION
Implement new SET_TRACKING_PROPERTY

New bridge method called SET_TRACKING_PROPERTY (defined [here](https://telefonicacorp.sharepoint.com/:w:/r/sites/Colabora_TCX/_layouts/15/Doc.aspx?sourcedoc=%7BEDD03AE1-B357-4F30-8128-69B8A8D167DD%7D&file=WebView%20Bridge.docx&wdOrigin=OFFICECOM-WEB.MAIN.SEARCH&ct=1620208356815&action=default&mobileredirect=true&cid=40118734-2c7e-4ad1-b8c3-d351dac503b8)) that will be used by some tracking sdks or features to receive values and properties from WebApp when they cannot be received from any other source. It receives three params:
- `system`: name of the system which will handle the property
- `name`: name of the property
- `value`: value of the property (nullable)

New cases are expected to be implemented soon in the apps for Medalia (12.5) and Palitagem (temptative 12.4, but maybe 12.5 too). But meanwhile unsupported system error is going to be returned.