### PR TITLE
WEB-188 Fix medallia typo in setTrackingProperty method

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Sets a property related to some specific tracking system
 -   Available for app versions 12.4 and higher
 
 ```typescript
-setTrackingProperty: (system: 'palitagem' | 'medalia', name: string, value?: string) => Promise<void>;
+setTrackingProperty: (system: 'palitagem' | 'medallia', name: string, value?: string) => Promise<void>;
 ```
 
 -   `system`: Tracking system that will handle the property

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -355,7 +355,7 @@ export const getCustomerHash = (): Promise<{hash: string}> =>
     });
 
 export const setTrackingProperty = (
-    system: 'palitagem' | 'medalia',
+    system: 'palitagem' | 'medallia',
     name: string,
     value?: string,
 ): Promise<void> =>

--- a/src/webview-bridge-cjs.js.flow
+++ b/src/webview-bridge-cjs.js.flow
@@ -223,7 +223,7 @@ declare export function getEsimInfo(): Promise<{|
 |}>;
 
 declare export function setTrackingProperty(
-    system: 'palitagem' | 'medalia',
+    system: 'palitagem' | 'medallia',
     name: string,
     value?: string,
 ): Promise<void>;


### PR DESCRIPTION
"medalia" available type for system should be "medallia" in `setTrackingProperty` method. Not breaking change because no one is currently using it. We can safely generate a new version without affecting anyone