### PR TITLE
WEB-324 Add SET_ACTION_BEHAVIOR method

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Alternatively, you can import the library directly from a CDN:
 -   [getDiskSpaceInfo](#getDiskSpaceInfo)
 -   [getEsimInfo](#getEsimInfo)
 -   [setTrackingProperty](#setTrackingProperty)
+-   [setActionBehavior](#setActionBehavior)
 
 ### isWebViewBridgeAvailable
 
@@ -693,6 +694,46 @@ setTrackingProperty: (system: 'palitagem' | 'medallia', name: string, value?: st
 -   `system`: Tracking system that will handle the property
 -   `name`: name of the property
 -   `value`: value of the property (nullable)
+
+### setActionBehavior
+
+Method that allows defining an specific behavior (such as showing a
+confirmation) before the specific native actions are executed. This method also
+allows disabling any previous behaviors set.
+
+-   Available for app versions 12.7 and higher
+
+```typescript
+type ActionBehavior = {
+    behavior: 'confirm' | 'default' | 'cancel';
+    title?: string;
+    message?: string;
+    acceptText?: string;
+    cancelText?: string;
+};
+
+setActionBehavior: (actions: {close?: ActionBehavior, back?: ActionBehavior}) => Promise<void>;
+```
+
+`close` and `back` actions are currently available:
+
+-   `back`: Action bar back button pressed (Also for physical back button in
+    android)
+-   `close`: Action bar close button pressed. Includes both “X” and “Close”
+    buttons.
+
+Both have same allowed json parameters, and 3 allowed behaviors:
+
+-   `confirm` Show a confirmation dialog with the required title and message. If
+    no accept or cancel texts are specified, native default ones will be used.
+-   `cancel` Prevent action from being performed, just ignoring it.
+-   `default` Set default behavior for the action. (Usually to reset any
+    previously specified behavior)
+
+Actions can be optionally included in the payload. Any not included action won’t
+change its current behavior set.
+
+All actions behaviors will be automatically set to default on full page loads.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -704,31 +704,39 @@ allows disabling any previous behaviors set.
 -   Available for app versions 12.7 and higher
 
 ```typescript
-type ActionBehavior = {
-    behavior: 'confirm' | 'default' | 'cancel';
-    title?: string;
-    message?: string;
-    acceptText?: string;
-    cancelText?: string;
-};
+type ActionBehavior =
+    | {
+        behavior: 'confirm';
+        title: string;
+        message: string;
+        acceptText: string;
+        cancelText: string;
+    }
+    | {
+        behavior: 'default';
+    }
+    | {
+        behavior: 'cancel';
+    };
 
-setActionBehavior: (actions: {close?: ActionBehavior, back?: ActionBehavior}) => Promise<void>;
+setActionBehavior: (actions: {webviewClose?: ActionBehavior, navigationBack?: ActionBehavior}) => Promise<void>;
 ```
 
-`close` and `back` actions are currently available:
+`navigationBack` and `webviewClose` actions are currently available:
 
--   `back`: Action bar back button pressed (Also for physical back button in
-    android)
--   `close`: Action bar close button pressed. Includes both “X” and “Close”
-    buttons.
+-   `navigationBack`: Action bar back button pressed (also for physical back
+    button in android but not swipe back gesture in iOS, which will be
+    disabled).
+-   `webviewClose`: Action bar close button pressed. Includes both "X" and
+    "Close" buttons (but not swipe down gesture in iOS, which will be disabled).
 
 Both have same allowed json parameters, and 3 allowed behaviors:
 
--   `confirm` Show a confirmation dialog with the required title and message. If
-    no accept or cancel texts are specified, native default ones will be used.
+-   `confirm` Show a confirmation dialog with the required title, message and
+    buttons.
 -   `cancel` Prevent action from being performed, just ignoring it.
 -   `default` Set default behavior for the action. (Usually to reset any
-    previously specified behavior)
+    previously specified behavior).
 
 Actions can be optionally included in the payload. Any not included action won’t
 change its current behavior set.

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ export {
     fetch,
     checkPermissionStatus,
     getAppMetadata,
+    setActionBehavior,
 } from './src/utils';
 export {createCalendarEvent} from './src/calendar';
 export {requestContact, fetchContactsByPhone} from './src/contacts';

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -421,14 +421,14 @@ test('get app metadata of installed application', async () => {
 
 test('set confirm action behavior', (done) => {
     const actions = {
-        close: {
+        webviewClose: {
             behavior: 'confirm',
             title: 'title',
             message: 'message',
             acceptText: 'acceptText',
             cancelText: 'cancelText',
         },
-        back: {
+        navigationBack: {
             behavior: 'confirm',
             title: 'title',
             message: 'message',

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -7,6 +7,7 @@ import {
     isABTestingAvailable,
     reportStatus,
     fetch,
+    setActionBehavior,
 } from '../utils';
 import {
     createFakeAndroidPostMessage,
@@ -415,5 +416,38 @@ test('get app metadata of installed application', async () => {
     await getAppMetadata(appToken).then((res) => {
         expect(res).toMatchObject({isInstalled: true, marketUrl, appUrl});
         removeFakeAndroidPostMessage();
+    });
+});
+
+test('set confirm action behavior', (done) => {
+    const actions = {
+        close: {
+            behavior: 'confirm',
+            title: 'title',
+            message: 'message',
+            acceptText: 'acceptText',
+            cancelText: 'cancelText',
+        },
+        back: {
+            behavior: 'confirm',
+            title: 'title',
+            message: 'message',
+            acceptText: 'acceptText',
+            cancelText: 'cancelText',
+        },
+    } as const;
+    createFakeAndroidPostMessage({
+        checkMessage: (msg) => {
+            expect(msg.type).toBe('SET_ACTION_BEHAVIOR');
+        },
+        getResponse: (msg) => ({
+            type: 'SET_ACTION_BEHAVIOR',
+            id: msg.id,
+        }),
+    });
+
+    setActionBehavior(actions).then((res) => {
+        expect(res).toBeUndefined();
+        done();
     });
 });

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -186,6 +186,11 @@ export type ResponsesFromNativeApp = {
         id: string;
         payload: void;
     };
+    SET_ACTION_BEHAVIOR: {
+        type: 'SET_ACTION_BEHAVIOR';
+        id: string;
+        payload: void;
+    };
 };
 
 export type NativeAppResponsePayload<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,13 +185,20 @@ export const getAppMetadata = (
         },
     });
 
-type ActionBehavior = {
-    behavior: 'confirm' | 'default' | 'cancel';
-    title?: string;
-    message?: string;
-    acceptText?: string;
-    cancelText?: string;
-};
+type ActionBehavior =
+    | {
+          behavior: 'confirm';
+          title: string;
+          message: string;
+          acceptText: string;
+          cancelText: string;
+      }
+    | {
+          behavior: 'default';
+      }
+    | {
+          behavior: 'cancel';
+      };
 
 export const setActionBehavior = (actions: {
     webviewClose?: ActionBehavior;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -194,8 +194,8 @@ type ActionBehavior = {
 };
 
 export const setActionBehavior = (actions: {
-    close?: ActionBehavior;
-    back?: ActionBehavior;
+    webviewClose?: ActionBehavior;
+    navigationBack?: ActionBehavior;
 }): Promise<void> =>
     postMessageToNativeApp({
         type: 'SET_ACTION_BEHAVIOR',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,3 +184,24 @@ export const getAppMetadata = (
             appToken,
         },
     });
+
+type ActionBehavior = {
+    behavior: 'confirm' | 'default' | 'cancel';
+    title?: string;
+    message?: string;
+    acceptText?: string;
+    cancelText?: string;
+};
+
+export const setActionBehavior = (actions: {
+    close?: ActionBehavior;
+    back?: ActionBehavior;
+}): Promise<void> =>
+    postMessageToNativeApp({
+        type: 'SET_ACTION_BEHAVIOR',
+        payload: {
+            actions: actions,
+        },
+    }).catch(() => {
+        // do nothing
+    });

--- a/src/webview-bridge-cjs.js.flow
+++ b/src/webview-bridge-cjs.js.flow
@@ -228,19 +228,22 @@ declare export function setTrackingProperty(
     value?: string,
 ): Promise<void>;
 
+type ActionBehavior =
+    | {
+          behavior: 'confirm',
+          title: string,
+          message: string,
+          acceptText: string,
+          cancelText: string,
+      }
+    | {
+          behavior: 'default',
+      }
+    | {
+          behavior: 'cancel',
+      };
+
 declare export function setActionBehavior(actions: {
-    close?: {
-        behavior: 'confirm' | 'default' | 'cancel',
-        title?: string,
-        message?: string,
-        acceptText?: string,
-        cancelText?: string,
-    },
-    back?: {
-        behavior: 'confirm' | 'default' | 'cancel',
-        title?: string,
-        message?: string,
-        acceptText?: string,
-        cancelText?: string,
-    },
+    webviewClose?: ActionBehavior,
+    navigationBack?: ActionBehavior,
 }): Promise<void>;

--- a/src/webview-bridge-cjs.js.flow
+++ b/src/webview-bridge-cjs.js.flow
@@ -227,3 +227,20 @@ declare export function setTrackingProperty(
     name: string,
     value?: string,
 ): Promise<void>;
+
+declare export function setActionBehavior(actions: {
+    close?: {
+        behavior: 'confirm' | 'default' | 'cancel',
+        title?: string,
+        message?: string,
+        acceptText?: string,
+        cancelText?: string,
+    },
+    back?: {
+        behavior: 'confirm' | 'default' | 'cancel',
+        title?: string,
+        message?: string,
+        acceptText?: string,
+        cancelText?: string,
+    },
+}): Promise<void>;


### PR DESCRIPTION
Method that allows defining an specific behavior (such as showing a confirmation) before the specific native actions are executed. This method also allows disabling any previous behaviors set. 

Request → 
```
{  
    "type": "SET_ACTION_BEHAVIOR", 
    "id": String, 
    "payload": { 
         "actions": { 
             (Optional) "close": { 
                 "behavior": "confirm" | "cancel" | "default", 
                 "title": String?, (Required if confirm) 
                 "message": String?, (Required if confirm) 
                 "acceptText": String?, (Required if confirm) 
                 "cancelText": String? (Required if confirm) 
             }, 
             (Optional) "back": { 
                 "behavior": "confirm" | "cancel" | "default 
                 "title": String?, (Required if confirm) 
                 "message": String?, (Required if confirm) 
                 "acceptText": String?, (Required if confirm) 
                 "cancelText": String? (Required if confirm) 
             } 
          }  
      } 
} 
```
 
Response → 
```
{  
    "type": "SET_ACTION_BEHAVIOR", 
    "id": String, 
}
````
Errors: 
```
400: Missing required payload 
```