### PR TITLE
Fix on setUserProperty function documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,10 +506,7 @@ setScreenName('Topup Flow', {someParam: 'some value'});
 Set a user property to firebase
 
 ```typescript
-setUserProperty: ({
-    name: string;
-    value: string;
-}) => Promise<void>;
+setUserProperty: (name: string, value: string) => Promise<void>;
 ```
 
 #### Example
@@ -517,10 +514,7 @@ setUserProperty: ({
 ```javascript
 import {setUserProperty} from '@tef-novum/webview-bridge';
 
-setUserProperty({
-    name: 'obIds',
-    value: 'any-value',
-}).then(() => {
+setUserProperty('obIds', 'any-value').then(() => {
     console.log('User property logged');
 });
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,9 +1351,9 @@ camelcase@^6.2.0:
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001292"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz#4a55f61c06abc9595965cfd77897dc7bc1cdc456"
-  integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
+  version "1.0.30001425"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz"
+  integrity sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
During the implementation  to add support of the setUserProperty on B2P app we stumbled upon this failure when calling the javascript function as documented:
> [WebViewsJavascript] console.warn: ["Trying to set analytics user property without name or value",{"name":"customProperty","value":"some value"},null] <WebView ID: 3>

Is it possible that the documentation is outdated? I PR a proposal for the fixed documentation