### PR TITLE
O2DE-2798 - Sanitize tracking params in setScreenView for iOs and Andoid

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -348,7 +348,7 @@ export const setScreenName = (
             if (androidFirebase.setScreenNameWithParams) {
                 androidFirebase.setScreenNameWithParams(
                     screenName,
-                    JSON.stringify(params),
+                    JSON.stringify(sanitizeAnalyticsParams(params)),
                 );
             } else if (androidFirebase.setScreenName) {
                 androidFirebase.setScreenName(screenName);
@@ -359,7 +359,7 @@ export const setScreenName = (
             iosFirebase.postMessage({
                 command: 'setScreenName',
                 name: screenName,
-                parameters: params,
+                parameters: sanitizeAnalyticsParams(params),
             });
             return Promise.resolve();
         },


### PR DESCRIPTION
Right now the tracking params are only sanitized for web, for maintain the consistency of the tracking events it should be sanitized for all environments.