### PR TITLE
O2DE-2474 support ß char in analytics events

### DIFF
--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -159,7 +159,7 @@ test('log GA4 event in Android', async () => {
     expect(androidFirebaseMock.logEvent).toBeCalledWith(
         'some_name',
         JSON.stringify({
-            component_copy: 'haz_click_en_este_boton_n_u_-_and___are_allowed',
+            component_copy: 'haz_click_en_este_boton_n_ß_u_-_and___are_allowed',
             screenName: '',
         }),
     );
@@ -178,7 +178,7 @@ test('log GA4 event in iOS', async () => {
         command: 'logEvent',
         name: 'some_name',
         parameters: {
-            component_copy: 'haz_click_en_este_boton_n_u_-_and___are_allowed',
+            component_copy: 'haz_click_en_este_boton_n_ß_u_-_and___are_allowed',
             screenName: '',
         },
     });
@@ -462,7 +462,7 @@ test('sanitizeAnalyticsParam', () => {
     );
     expect(
         sanitizeAnalyticsParam('some special chars ñ ß ü % € and more text'),
-    ).toBe('some_special_chars_n_u_and_more_text');
+    ).toBe('some_special_chars_n_ß_u_and_more_text');
     expect(sanitizeAnalyticsParam('some_all:owed-special/chars|')).toBe(
         'some_all:owed-special/chars|',
     );

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -126,20 +126,14 @@ const EVENT_PARAM_NAME_CHARS_LIMIT = 40;
 const EVENT_PARAM_VALUE_CHARS_LIMIT = 100;
 const EVENT_PARAMS_LIMIT = 25;
 
-export const sanitizeAnalyticsParam = (
-    str: string,
-    options?: {keepBlanks?: boolean},
-): string => {
-    let sanitized = removeAccents(str)
+export const sanitizeAnalyticsParam = (str: string): string =>
+    removeAccents(str)
         .toLocaleLowerCase()
         .replace(/[^a-zß0-9\s\-\_\/\|\:]/g, '') // Remove all non allowed characters
         .replace(/\s+/g, ' ') // Replace repeated whitespaces with a single space
-        .trim();
-    if (!options?.keepBlanks) {
-        sanitized = sanitized.replace(/\s/g, '_'); // Replace spaces with underscores
-    }
-    return sanitized.slice(0, EVENT_PARAM_VALUE_CHARS_LIMIT);
-};
+        .trim()
+        .replace(/\s/g, '_') // Replace spaces with underscores
+        .slice(0, EVENT_PARAM_VALUE_CHARS_LIMIT);
 
 export const sanitizeAnalyticsParams = (params: {
     [key: string]: unknown;

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -126,14 +126,20 @@ const EVENT_PARAM_NAME_CHARS_LIMIT = 40;
 const EVENT_PARAM_VALUE_CHARS_LIMIT = 100;
 const EVENT_PARAMS_LIMIT = 25;
 
-export const sanitizeAnalyticsParam = (str: string): string =>
-    removeAccents(str)
+export const sanitizeAnalyticsParam = (
+    str: string,
+    options?: {keepBlanks?: boolean},
+): string => {
+    let sanitized = removeAccents(str)
         .toLocaleLowerCase()
-        .replace(/[^a-z0-9\s\-\_\/\|\:]/g, '') // Remove all non allowed characters
+        .replace(/[^a-zß0-9\s\-\_\/\|\:]/g, '') // Remove all non allowed characters
         .replace(/\s+/g, ' ') // Replace repeated whitespaces with a single space
-        .trim()
-        .replace(/\s/g, '_') // Replace spaces with underscores
-        .slice(0, EVENT_PARAM_VALUE_CHARS_LIMIT);
+        .trim();
+    if (!options?.keepBlanks) {
+        sanitized = sanitized.replace(/\s/g, '_'); // Replace spaces with underscores
+    }
+    return sanitized.slice(0, EVENT_PARAM_VALUE_CHARS_LIMIT);
+};
 
 export const sanitizeAnalyticsParams = (params: {
     [key: string]: unknown;


### PR DESCRIPTION
~~The idea is this method to replace this one at webapp: https://github.com/Telefonica/webapp/blob/c9fc7a0cd4616fe59ffeca0269897ca0c1618524/web/src/common/stats/analytics.tsx#L403~~

Also, it will leave the german ß char untouched