### PR TITLE
O2DEB2P-744 Bridge method to request the native app to open de onboarding experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,14 @@ To inspect the bridge traffic, you can use the `setLogger` method:
 setLogger((...args) => console.log(...args));
 ```
 
+### openOnboarding
+
+Opens the app Onboarding (as if it where the first time the user logs in)
+
+```ts
+openOnboarding = () => Promise<void>
+```
+
 ## License
 
 This project is licensed under the terms of the MIT license. See the

--- a/index.ts
+++ b/index.ts
@@ -84,3 +84,5 @@ export type {
     SheetActionItem,
     SheetInfoItem,
 } from './src/bottom-sheet';
+
+export {openOnboarding} from './src/open-onboarding';

--- a/src/__tests__/open-onboarding-test.ts
+++ b/src/__tests__/open-onboarding-test.ts
@@ -1,4 +1,4 @@
-import {openOnboading} from '../open-onboarding';
+import {openOnboarding} from '../open-onboarding';
 import {
     createFakeAndroidPostMessage,
     removeFakeAndroidPostMessage,
@@ -19,7 +19,7 @@ test('webapp requests to show the onboarding', (done) => {
         }),
     });
 
-    openOnboading().then((res) => {
+    openOnboarding().then((res) => {
         expect(res).toBeUndefined();
         done();
     });

--- a/src/__tests__/open-onboarding-test.ts
+++ b/src/__tests__/open-onboarding-test.ts
@@ -1,4 +1,4 @@
-import {showAppRating} from '../app-rating';
+import {openOnboading} from '../open-onboarding';
 import {
     createFakeAndroidPostMessage,
     removeFakeAndroidPostMessage,
@@ -8,10 +8,10 @@ afterEach(() => {
     removeFakeAndroidPostMessage();
 });
 
-test('webapp requests to show the app rating', (done) => {
+test('webapp requests to show the onboarding', (done) => {
     createFakeAndroidPostMessage({
         checkMessage: (message) => {
-            expect(message.type).toBe('SHOW_APP_RATING');
+            expect(message.type).toBe('OPEN_ONBOARDING');
         },
         getResponse: (message) => ({
             type: message.type,
@@ -19,7 +19,7 @@ test('webapp requests to show the app rating', (done) => {
         }),
     });
 
-    showAppRating().then((res) => {
+    openOnboading().then((res) => {
         expect(res).toBeUndefined();
         done();
     });

--- a/src/open-onboarding.ts
+++ b/src/open-onboarding.ts
@@ -1,0 +1,7 @@
+import {postMessageToNativeApp} from './post-message';
+
+/**
+ * This method is used by webapp to request the native app to launch the app rating dialog
+ */
+export const openOnboarding = (): Promise<void> =>
+    postMessageToNativeApp({type: 'OPEN_ONBOARDING'});

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -260,6 +260,11 @@ export type ResponsesFromNativeApp = {
         id: string;
         payload: {model: string};
     };
+    OPEN_ONBOARDING: {
+        type: 'OPEN_ONBOARDING';
+        id: string;
+        payload: void;
+    };
 };
 
 export type NativeAppResponsePayload<


### PR DESCRIPTION
On B2P apps we have the request to enable a way for the OB webviews to request the Onboarding to be opened again on demand.

Message type has already been agreed with Apps teams as "OPEN_ONBOARDING"