### PR TITLE
WEB-1662 Add PERMISSION_REQUIRED enum value to DATA_CONNECTION_INFO method

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,7 +994,7 @@ Obtain metainformation about the current device data network connectivity
 ```ts
 getNetworkConnectionInfo: () => Promise<{
     connectionType: 'MOBILE' | 'WIFI ' | 'OTHER' | 'NONE';
-    mobileConnectionType?: '2G' | '3G' | '4G' | '5G' | 'OTHER' | null;
+    mobileConnectionType?: '2G' | '3G' | '4G' | '5G' | 'OTHER' | 'PERMISSION_REQUIRED' | null;
     mobileCarrier?: string | null;
     mobileSignalStrength?: 'NONE' | 'POOR' | 'MODERATE' | 'GOOD' | 'GREAT' | null;
 }>;
@@ -1002,7 +1002,7 @@ getNetworkConnectionInfo: () => Promise<{
 
 -   `connectionType`: describes the network technology used currently for data
 -   `mobileConnectionType`: in case connectionType is 'MOBILE' gives further
-    details about the network technology used.
+    details about the network technology used. PERMISSION_REQUIRED value will be returned only in Android when READ_PHONE_STATE permission has not been granted by the user. The permission request is already managed by the Android implementation itself.
 -   `mobileCarrier`: identifies the carrier used for 'MOBILE' connectionType
 -   `mobileSignalStrength`: gives a measure of the current signal strength for
     'MOBILE' connectionType.

--- a/README.md
+++ b/README.md
@@ -994,9 +994,22 @@ Obtain metainformation about the current device data network connectivity
 ```ts
 getNetworkConnectionInfo: () => Promise<{
     connectionType: 'MOBILE' | 'WIFI ' | 'OTHER' | 'NONE';
-    mobileConnectionType?: '2G' | '3G' | '4G' | '5G' | 'OTHER' | 'PERMISSION_REQUIRED' | null;
+    mobileConnectionType?: 
+        | '2G'
+        | '3G'
+        | '4G'
+        | '5G'
+        | 'OTHER'
+        | 'PERMISSION_REQUIRED'
+        | null;
     mobileCarrier?: string | null;
-    mobileSignalStrength?: 'NONE' | 'POOR' | 'MODERATE' | 'GOOD' | 'GREAT' | null;
+    mobileSignalStrength?: 
+        | 'NONE'
+        | 'POOR'
+        | 'MODERATE'
+        | 'GOOD'
+        | 'GREAT' 
+        | null;
 }>;
 ```
 

--- a/README.md
+++ b/README.md
@@ -994,7 +994,7 @@ Obtain metainformation about the current device data network connectivity
 ```ts
 getNetworkConnectionInfo: () => Promise<{
     connectionType: 'MOBILE' | 'WIFI ' | 'OTHER' | 'NONE';
-    mobileConnectionType?: 
+    mobileConnectionType?:
         | '2G'
         | '3G'
         | '4G'
@@ -1003,19 +1003,22 @@ getNetworkConnectionInfo: () => Promise<{
         | 'PERMISSION_REQUIRED'
         | null;
     mobileCarrier?: string | null;
-    mobileSignalStrength?: 
+    mobileSignalStrength?:
         | 'NONE'
         | 'POOR'
         | 'MODERATE'
         | 'GOOD'
-        | 'GREAT' 
+        | 'GREAT'
         | null;
 }>;
 ```
 
 -   `connectionType`: describes the network technology used currently for data
 -   `mobileConnectionType`: in case connectionType is 'MOBILE' gives further
-    details about the network technology used. PERMISSION_REQUIRED value will be returned only in Android when READ_PHONE_STATE permission has not been granted by the user. The permission request is already managed by the Android implementation itself.
+    details about the network technology used. PERMISSION_REQUIRED value will be
+    returned only in Android when READ_PHONE_STATE permission has not been
+    granted by the user. The permission request is already managed by the
+    Android implementation itself.
 -   `mobileCarrier`: identifies the carrier used for 'MOBILE' connectionType
 -   `mobileSignalStrength`: gives a measure of the current signal strength for
     'MOBILE' connectionType.

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -38,7 +38,14 @@ export type SnackbarResponse = {
 
 type DataConnectionResponse = {
     connectionType: 'MOBILE' | 'WIFI ' | 'OTHER' | 'NONE';
-    mobileConnectionType?: '2G' | '3G' | '4G' | '5G' | 'OTHER' | null;
+    mobileConnectionType?:
+        | '2G'
+        | '3G'
+        | '4G'
+        | '5G'
+        | 'OTHER'
+        | 'PERMISSION_REQUIRED'
+        | null;
     mobileCarrier?: string | null;
     mobileSignalStrength?:
         | 'NONE'


### PR DESCRIPTION
When `READ_PHONE_STATE` permission (only required for `mobileConnectionType` field in Android) is not granted when `DATA_CONNECTION_INFO` bridge method is invoked, we are now returning a new `PERMISSION_REQUIRED` enum value inside `mobileConnectionType` field instead of returned a whole error response. This allow to avoid valuable information that can be used even when the user denies the permission.