### PR TITLE
try to use web clipboard api when possible

### DIFF
--- a/src/__tests__/clipboard-test.ts
+++ b/src/__tests__/clipboard-test.ts
@@ -1,6 +1,44 @@
 import {readTextFromClipboard, writeTextToClipboard} from '../../index';
 import {createFakeWebKitPostMessage} from './fake-post-message';
 
+const originalClipboard = navigator.clipboard;
+
+const mockClipboardApi = () => {
+    const readTextSpy = jest.fn();
+    const writeTextSpy = jest.fn();
+    Object.defineProperty(navigator, 'clipboard', {
+        value: {
+            readText: readTextSpy,
+            writeText: writeTextSpy,
+        },
+        writable: true,
+    });
+    return {readTextSpy, writeTextSpy};
+};
+
+beforeEach(() => {
+    (navigator as any).clipboard = originalClipboard;
+});
+
+test('read from clipboard when web api is available', async () => {
+    const {readTextSpy} = mockClipboardApi();
+    readTextSpy.mockResolvedValue('some text');
+
+    const res = await readTextFromClipboard();
+
+    expect(readTextSpy).toHaveBeenCalledTimes(1);
+    expect(res).toEqual('some text');
+});
+
+test('write to clipboard when web api is available', async () => {
+    const {writeTextSpy} = mockClipboardApi();
+    writeTextSpy.mockResolvedValue(undefined);
+
+    await writeTextToClipboard('some text');
+
+    expect(writeTextSpy).toHaveBeenCalledWith('some text');
+});
+
 test('read from clipboard', async () => {
     createFakeWebKitPostMessage({
         checkMessage: (msg) => {
@@ -19,6 +57,46 @@ test('read from clipboard', async () => {
 });
 
 test('write to clipboard', async () => {
+    createFakeWebKitPostMessage({
+        checkMessage: (msg) => {
+            expect(msg.type).toBe('CLIPBOARD_WRITE_TEXT');
+            expect(msg.payload).toBe('some text');
+        },
+        getResponse: (msg) => ({
+            type: 'CLIPBOARD_WRITE_TEXT',
+            id: msg.id,
+        }),
+    });
+
+    await writeTextToClipboard('some text');
+});
+
+test('read from clipboard when web api throws', async () => {
+    const {readTextSpy} = mockClipboardApi();
+
+    readTextSpy.mockRejectedValue(new Error('Not allowed'));
+
+    createFakeWebKitPostMessage({
+        checkMessage: (msg) => {
+            expect(msg.type).toBe('CLIPBOARD_READ_TEXT');
+        },
+        getResponse: (msg) => ({
+            type: 'CLIPBOARD_READ_TEXT',
+            payload: 'some text',
+            id: msg.id,
+        }),
+    });
+
+    const res = await readTextFromClipboard();
+
+    expect(res).toEqual('some text');
+});
+
+test('write to clipboard when web api throws', async () => {
+    const {writeTextSpy} = mockClipboardApi();
+
+    writeTextSpy.mockRejectedValue(new Error('Not allowed'));
+
     createFakeWebKitPostMessage({
         checkMessage: (msg) => {
             expect(msg.type).toBe('CLIPBOARD_WRITE_TEXT');

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,7 +1,29 @@
 import {postMessageToNativeApp} from './post-message';
 
+/**
+ * These functions try to use the Web Clipboard API if available, otherwise fall back to the bridge
+ * implementation in native apps.
+ *
+ * According to the tests done, the Web Clipboard API works fine in iOS webviews but fails with a permissions
+ * error in Android in some cases. Also, old versions of Chrome in Android may not have support for the Web
+ * Clipboard API at all.
+ *
+ * We have decided to not implement the bridge method in iOS apps, as the Web Clipboard API works fine.
+ */
+
 export const readTextFromClipboard = (): Promise<string> =>
-    postMessageToNativeApp({type: 'CLIPBOARD_READ_TEXT'});
+    (navigator.clipboard?.readText
+        ? navigator.clipboard.readText()
+        : Promise.reject()
+    ).catch(() => postMessageToNativeApp({type: 'CLIPBOARD_READ_TEXT'}));
 
 export const writeTextToClipboard = (text: string): Promise<void> =>
-    postMessageToNativeApp({type: 'CLIPBOARD_WRITE_TEXT', payload: text});
+    (navigator.clipboard?.writeText
+        ? navigator.clipboard.writeText(text)
+        : Promise.reject()
+    ).catch(() =>
+        postMessageToNativeApp({
+            type: 'CLIPBOARD_WRITE_TEXT',
+            payload: text,
+        }),
+    );


### PR DESCRIPTION
With this changes we won't need to implement the bridge method in iOS, as Web Clipboard Api works fine in Safari webviews