### PR TITLE
feat(refreshNavBar): new method to refresh navigation bar with the response of Visual Modules API

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ downloadBase64({
 expandedTitle</kbd><br/> <kbd>App version >= 14.8: Additional properties and
 deprecations</kbd><br/> <kbd>Partial support in B2P App version <=24.10:
 title</kbd><br/> <kbd>Partial support in B2P App version >=24.11: right
-actions</kbd><br/> <kbd>Full support in B2P App version >=24.12: title</kbd>
+actions</kbd><br/>
 
 Customize WebView NavigationBar properties. You can set one or more properties
 in a single call
@@ -1571,6 +1571,39 @@ isQualtricsInterceptAvailableForUser: ({interceptId: string}) => Promise<{isAvai
     code: 501;
     reason: 'SDK not initialized';
 }
+```
+
+### refreshNavBar
+
+Method that allows WebView to refresh the navigation bars that are retrieved by
+Visual Modules API
+
+```ts
+refreshNavBar: ({
+    module-id?: string,
+    product-id?: string
+}) => Promise<void>;
+```
+
+where
+
+-   `module-id` is an optional parameter
+    -   If it is not included, it means the app will refresh top and bottom bar
+    -   If it is included, it should be the same values used for Visual Modules
+        API and the app will request to refresh only the indicated bar
+-   `product-id` is an optional parameter
+    -   If it is not included, visual modules is requested as it is today, just
+        with the userID as query param plus the `module-id`
+    -   If it is included, visual modules will be requested for the current
+        userID and for the `product-id`
+
+#### Example
+
+```ts
+refreshNavBar({
+    module-id: 'bottombar',
+    product-id: 'ID_00fe00a87b2',
+});
 ```
 
 ## Error handling

--- a/README.md
+++ b/README.md
@@ -1580,29 +1580,29 @@ Visual Modules API
 
 ```ts
 refreshNavBar: ({
-    module-id?: string,
-    product-id?: string
+    moduleId?: string,
+    productId?: string
 }) => Promise<void>;
 ```
 
 where
 
--   `module-id` is an optional parameter
+-   `moduleId` is an optional parameter
     -   If it is not included, it means the app will refresh top and bottom bar
     -   If it is included, it should be the same values used for Visual Modules
         API and the app will request to refresh only the indicated bar
--   `product-id` is an optional parameter
+-   `productId` is an optional parameter
     -   If it is not included, visual modules is requested as it is today, just
-        with the userID as query param plus the `module-id`
+        with the userID as query param plus the `moduleId`
     -   If it is included, visual modules will be requested for the current
-        userID and for the `product-id`
+        userID and for the `productId`
 
 #### Example
 
 ```ts
 refreshNavBar({
-    module-id: 'bottombar',
-    product-id: 'ID_00fe00a87b2',
+    moduleId: 'bottombar',
+    productId: 'ID_00fe00a87b2',
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -552,6 +552,8 @@ nativeMessage({
 
 ### logEvent
 
+<kbd>Available in B2P App version >=24.10</kbd>
+
 Log an event to firebase
 
 ```ts
@@ -610,6 +612,8 @@ logEvent(yourEvent, {sanitize: false});
 
 ### setScreenName
 
+<kbd>Available in B2P App version >=24.10</kbd>
+
 Log the current screen name (or page name) to firebase
 
 ```ts
@@ -617,6 +621,8 @@ setScreenName: (screenName: string, params?: {[key: string]: any}) => Promise<vo
 ```
 
 ### setUserProperty
+
+<kbd>Available in B2P App version >=24.10</kbd>
 
 Set a user property to firebase
 
@@ -706,7 +712,7 @@ internalNavigation: (feature: string) => Promise<void>;
 
 ### dismiss
 
-<kbd>App version >=11.5</kbd>
+<kbd>App version >=11.5</kbd> <kbd>Available in B2P App version >=24.10</kbd>
 
 Dismiss the current webview and optionally navigate to another url
 

--- a/index.ts
+++ b/index.ts
@@ -62,7 +62,7 @@ export {
     updatePhoneNumbers,
 } from './src/contacts';
 
-export {highlightNavigationTab} from './src/navigation-tabs';
+export {highlightNavigationTab, refreshNavBar} from './src/navigation-tabs';
 
 export {
     logEvent,

--- a/src/__tests__/navigation-tabs-test.ts
+++ b/src/__tests__/navigation-tabs-test.ts
@@ -43,10 +43,8 @@ test('refresh navigation bars with params', (done) => {
         }),
     });
 
-    refreshNavBar({moduleId: MODULE_ID, productId: PRODUCT_ID}).then(
-        (res) => {
-            expect(res).toBeUndefined();
-            done();
-        },
-    );
+    refreshNavBar({moduleId: MODULE_ID, productId: PRODUCT_ID}).then((res) => {
+        expect(res).toBeUndefined();
+        done();
+    });
 });

--- a/src/__tests__/navigation-tabs-test.ts
+++ b/src/__tests__/navigation-tabs-test.ts
@@ -1,0 +1,52 @@
+import {refreshNavBar} from '../navigation-tabs';
+import {
+    createFakeAndroidPostMessage,
+    removeFakeAndroidPostMessage,
+} from './fake-post-message';
+
+const MODULE_ID = 'bottombar';
+const PRODUCT_ID = 'myProductId';
+
+afterEach(() => {
+    removeFakeAndroidPostMessage();
+});
+
+test('refresh navigation bars without params', (done) => {
+    createFakeAndroidPostMessage({
+        checkMessage: (message) => {
+            expect(message.type).toBe('REFRESH_NAV_BAR');
+        },
+        getResponse: (message) => ({
+            type: message.type,
+            id: message.id,
+        }),
+    });
+
+    refreshNavBar({}).then((res) => {
+        expect(res).toBeUndefined();
+        done();
+    });
+});
+
+test('refresh navigation bars with params', (done) => {
+    createFakeAndroidPostMessage({
+        checkMessage: (message) => {
+            expect(message.type).toBe('REFRESH_NAV_BAR');
+            expect(message.payload).toEqual({
+                module_id: MODULE_ID,
+                product_id: PRODUCT_ID,
+            });
+        },
+        getResponse: (message) => ({
+            type: message.type,
+            id: message.id,
+        }),
+    });
+
+    refreshNavBar({module_id: MODULE_ID, product_id: PRODUCT_ID}).then(
+        (res) => {
+            expect(res).toBeUndefined();
+            done();
+        },
+    );
+});

--- a/src/__tests__/navigation-tabs-test.ts
+++ b/src/__tests__/navigation-tabs-test.ts
@@ -33,8 +33,8 @@ test('refresh navigation bars with params', (done) => {
         checkMessage: (message) => {
             expect(message.type).toBe('REFRESH_NAV_BAR');
             expect(message.payload).toEqual({
-                module_id: MODULE_ID,
-                product_id: PRODUCT_ID,
+                moduleId: MODULE_ID,
+                productId: PRODUCT_ID,
             });
         },
         getResponse: (message) => ({
@@ -43,7 +43,7 @@ test('refresh navigation bars with params', (done) => {
         }),
     });
 
-    refreshNavBar({module_id: MODULE_ID, product_id: PRODUCT_ID}).then(
+    refreshNavBar({moduleId: MODULE_ID, productId: PRODUCT_ID}).then(
         (res) => {
             expect(res).toBeUndefined();
             done();

--- a/src/navigation-tabs.ts
+++ b/src/navigation-tabs.ts
@@ -17,3 +17,21 @@ export const highlightNavigationTab = ({
             count,
         },
     });
+
+/**
+ * Request the app to refresh the navigation bars
+ */
+export const refreshNavBar = ({
+    module_id,
+    product_id
+}: {
+    module_id?: string; // module id used in Visual Modules API
+    product_id?: string; // identifier of the product as it is in Subscribed Products API
+}): Promise<void> =>
+    postMessageToNativeApp({
+        type: 'REFRESH_NAV_BAR',
+        payload: {
+            module_id,
+            product_id
+        },
+    });

--- a/src/navigation-tabs.ts
+++ b/src/navigation-tabs.ts
@@ -23,7 +23,7 @@ export const highlightNavigationTab = ({
  */
 export const refreshNavBar = ({
     module_id,
-    product_id
+    product_id,
 }: {
     module_id?: string; // module id used in Visual Modules API
     product_id?: string; // identifier of the product as it is in Subscribed Products API
@@ -32,6 +32,6 @@ export const refreshNavBar = ({
         type: 'REFRESH_NAV_BAR',
         payload: {
             module_id,
-            product_id
+            product_id,
         },
     });

--- a/src/navigation-tabs.ts
+++ b/src/navigation-tabs.ts
@@ -22,16 +22,16 @@ export const highlightNavigationTab = ({
  * Request the app to refresh the navigation bars
  */
 export const refreshNavBar = ({
-    module_id,
-    product_id,
+    moduleId,
+    productId,
 }: {
-    module_id?: string; // module id used in Visual Modules API
-    product_id?: string; // identifier of the product as it is in Subscribed Products API
+    moduleId?: string; // module id used in Visual Modules API
+    productId?: string; // identifier of the product as it is in Subscribed Products API
 }): Promise<void> =>
     postMessageToNativeApp({
         type: 'REFRESH_NAV_BAR',
         payload: {
-            module_id,
-            product_id,
+            moduleId,
+            productId,
         },
     });

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -432,6 +432,11 @@ export type ResponsesFromNativeApp = {
         id: string;
         payload: {isAvailable: boolean};
     };
+    REFRESH_NAV_BAR: {
+        type: 'REFRESH_NAV_BAR';
+        id: string;
+        payload: void;
+    };
 };
 
 export type NativeAppResponsePayload<


### PR DESCRIPTION
We need to create a new method so the webview can tell the app to refresh the navigation bars that are displayed by using the Visual Modules API.

The idea for this new method is that it has two parameters that are both optional: module-id and product-id. So the method can be called with no parameters, just one of them, or both.

https://jira.tid.es/browse/B2PDE-1403

closes #194 