### PR TITLE
B2PDE-1447 implements getAppDomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,8 @@ fetchContactsByPhone: (phoneNumbers: Array<string>) => Promise<Array<{
 ```
 ### getAppDomain
 
+<kbd>Available in B2P App version >=25.3</kbd>
+
 Return info about appDomain
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ Return info about appDomain
 ```ts
 getAppDomain: () => Promise<{domain: string}>;
 ```
+`domain`: the domain value of the environment that the app is pointing to.
 
 ### getAppMetadata
 

--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ Return info about appDomain
 ```ts
 getAppDomain: () => Promise<{domain: string}>;
 ```
+
 `domain`: the domain value of the environment that the app is pointing to.
 
 ### getAppMetadata

--- a/README.md
+++ b/README.md
@@ -741,6 +741,7 @@ fetchContactsByPhone: (phoneNumbers: Array<string>) => Promise<Array<{
     encodedAvatar?: string;
 }>>;
 ```
+
 ### getAppDomain
 
 <kbd>Available in B2P App version >=25.3</kbd>

--- a/README.md
+++ b/README.md
@@ -741,6 +741,13 @@ fetchContactsByPhone: (phoneNumbers: Array<string>) => Promise<Array<{
     encodedAvatar?: string;
 }>>;
 ```
+### getAppDomain
+
+Return info about appDomain
+
+```ts
+getAppDomain: () => Promise<{domain: string}>;
+```
 
 ### getAppMetadata
 

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ export {
     downloadBase64,
     getBatteryInfo,
     getInstallationId,
+    getAppDomain,
 } from './src/device';
 
 export {

--- a/src/__tests__/device-test.ts
+++ b/src/__tests__/device-test.ts
@@ -13,7 +13,7 @@ import {
     downloadBase64,
     getBatteryInfo,
 } from '../../index';
-import {getInstallationId} from '../device';
+import {getAppDomain, getInstallationId} from '../device';
 import {
     createFakeAndroidPostMessage,
     removeFakeAndroidPostMessage,
@@ -467,5 +467,25 @@ test('getInstallationId', async () => {
 
     expect(res).toEqual({
         installationId: '123',
+    });
+});
+test('getAppDomain', async () => {
+    createFakeWebKitPostMessage({
+        checkMessage: (msg) => {
+            expect(msg.type).toBe('GET_APP_DOMAIN');
+        },
+        getResponse: (msg) => ({
+            type: 'GET_APP_DOMAIN',
+            id: msg.id,
+            payload: {
+                appDomain: '123',
+            },
+        }),
+    });
+
+    const res = await getInstallationId();
+
+    expect(res).toEqual({
+        appDomain: '123',
     });
 });

--- a/src/__tests__/device-test.ts
+++ b/src/__tests__/device-test.ts
@@ -469,6 +469,7 @@ test('getInstallationId', async () => {
         installationId: '123',
     });
 });
+
 test('getAppDomain', async () => {
     createFakeWebKitPostMessage({
         checkMessage: (msg) => {
@@ -483,7 +484,7 @@ test('getAppDomain', async () => {
         }),
     });
 
-    const res = await getInstallationId();
+    const res = await getAppDomain();
 
     expect(res).toEqual({
         appDomain: '123',

--- a/src/__tests__/device-test.ts
+++ b/src/__tests__/device-test.ts
@@ -479,7 +479,7 @@ test('getAppDomain', async () => {
             type: 'GET_APP_DOMAIN',
             id: msg.id,
             payload: {
-                appDomain: '123',
+                appDomain: 'https://example.com',
             },
         }),
     });
@@ -487,6 +487,6 @@ test('getAppDomain', async () => {
     const res = await getAppDomain();
 
     expect(res).toEqual({
-        appDomain: '123',
+        appDomain: 'https://example.com',
     });
 });

--- a/src/device.ts
+++ b/src/device.ts
@@ -112,3 +112,6 @@ export const getBatteryInfo = (): Promise<{
 
 export const getInstallationId = (): Promise<{installationId: string}> =>
     postMessageToNativeApp({type: 'GET_INSTALLATION_ID'});
+
+export const getAppDomain = (): Promise<{appDomain: string}> =>
+    postMessageToNativeApp({type: 'GET_APP_DOMAIN'});

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -435,6 +435,11 @@ export type ResponsesFromNativeApp = {
         id: string;
         payload: void;
     };
+    GET_APP_DOMAIN: {
+        type: 'GET_APP_DOMAIN';
+        id: string;
+        payload: {appDomain: string};
+    };
 };
 
 export type NativeAppResponsePayload<


### PR DESCRIPTION
This PR introduces the `getAppDomain` function, which allows retrieving the domain of the application where the WebView bridge is running. This functionality is useful for identifying the application context and adjusting specific behaviors based on the domain.

closes #195 