### PR TITLE
B2PDE-1529 fix getAppDomain payload to match the documentation

### DIFF
--- a/src/__tests__/device-test.ts
+++ b/src/__tests__/device-test.ts
@@ -479,7 +479,7 @@ test('getAppDomain', async () => {
             type: 'GET_APP_DOMAIN',
             id: msg.id,
             payload: {
-                appDomain: 'https://example.com',
+                domain: 'https://example.com',
             },
         }),
     });
@@ -487,6 +487,6 @@ test('getAppDomain', async () => {
     const res = await getAppDomain();
 
     expect(res).toEqual({
-        appDomain: 'https://example.com',
+        domain: 'https://example.com',
     });
 });

--- a/src/device.ts
+++ b/src/device.ts
@@ -113,5 +113,5 @@ export const getBatteryInfo = (): Promise<{
 export const getInstallationId = (): Promise<{installationId: string}> =>
     postMessageToNativeApp({type: 'GET_INSTALLATION_ID'});
 
-export const getAppDomain = (): Promise<{appDomain: string}> =>
+export const getAppDomain = (): Promise<{domain: string}> =>
     postMessageToNativeApp({type: 'GET_APP_DOMAIN'});

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -443,7 +443,7 @@ export type ResponsesFromNativeApp = {
     GET_APP_DOMAIN: {
         type: 'GET_APP_DOMAIN';
         id: string;
-        payload: {appDomain: string};
+        payload: {domain: string};
     };
 };
 


### PR DESCRIPTION
In the JS library implementation, getAppDomain payload is wrong as it doesn't match the documentation:

{domain: string} vs {appDomain:string}

As the documentation has already been shared with the OB, we'll change the implementation (no other native code is yet usgin this message)
