### PR TITLE
Improve dismiss method documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ internalNavigation: (feature: string) => Promise<void>;
 
 <kbd>App version >=11.5</kbd> <kbd>Available in B2P App version >=24.10</kbd>
 
-Dismiss the current webview if possible and optionally navigate to another URL. If we can't do the dismiss, the optional URL won't be opened.
+Dismiss the current webview if possible and optionally navigate to another URL. If we can't do the dismiss, for example, if the webview is one of the main tabs, the optional URL won't be opened.
 
 ```ts
 dismiss: (onCompletionUrl?: string) => Promise<void>;

--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ dismiss: (onCompletionUrl?: string) => Promise<void>;
 ```ts
 {
     code: 405;
-    reason: 'Webview is not allowed to dismiss';
+    reason: 'Webview is not allowed to dismiss because we only have one webview instance in the navigation stack.';
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -714,10 +714,19 @@ internalNavigation: (feature: string) => Promise<void>;
 
 <kbd>App version >=11.5</kbd> <kbd>Available in B2P App version >=24.10</kbd>
 
-Dismiss the current webview and optionally navigate to another url
+Dismiss the current webview if possible and optionally navigate to another URL. If we can't do the dismiss, the optional URL won't be opened.
 
 ```ts
 dismiss: (onCompletionUrl?: string) => Promise<void>;
+```
+
+#### Error cases
+
+```ts
+{
+    code: 405;
+    reason: 'Webview is not allowed to dismiss';
+}
 ```
 
 ### requestVibration

--- a/README.md
+++ b/README.md
@@ -714,7 +714,9 @@ internalNavigation: (feature: string) => Promise<void>;
 
 <kbd>App version >=11.5</kbd> <kbd>Available in B2P App version >=24.10</kbd>
 
-Dismiss the current webview if possible and optionally navigate to another URL. If we can't do the dismiss, for example, if the webview is one of the main tabs, the optional URL won't be opened.
+Dismiss the current webview if possible and optionally navigate to another URL.
+If we can't do the dismiss, for example, if the webview is one of the main tabs,
+the optional URL won't be opened.
 
 ```ts
 dismiss: (onCompletionUrl?: string) => Promise<void>;


### PR DESCRIPTION
In order to align iOS and Android `dismiss` method implementation, I'm adding more details in the README.