### PR TITLE
feat(triggerPinOrBiometricAuthentication): support new DEVICE_HAS_NO_AUTHENTICATION result case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,13 +1267,23 @@ possible scenarios:
 triggerPinOrBiometricAuthentication: ({
     maxSecondsSinceLastValidation: number
 }) => Promise<{
-    result: 'USER_AUTHENTICATED' | 'USER_ENABLED_AUTHENTICATION' | 'LAST_AUTHENTICATION_STILL_VALID',
+    result: 'USER_AUTHENTICATED' | 'USER_ENABLED_AUTHENTICATION' | 'LAST_AUTHENTICATION_STILL_VALID' | 'DEVICE_HAS_NO_AUTHENTICATION',
 }>;
 ```
 
 -   `maxSecondsSinceLastValidation`: if time elapsed since last authentication
     is less than the number of seconds specified here authentication will
     succeed without requesting it again.
+
+<kbd>App version >=25.5</kbd>
+
+If the new PIN & Biometrics 2.0 (device authentication) feature is enabled,
+there are a couple of details to take into account:
+
+-   If the setting is not enabled by the user, the device authentication will be
+    asked and if it goes right, the setting will be enabled.
+-   If the device doesn't have any authentication configured, the method will
+    return `DEVICE_HAS_NO_AUTHENTICATION` as result.
 
 ### focusNavbar
 

--- a/src/post-message.ts
+++ b/src/post-message.ts
@@ -339,7 +339,8 @@ export type ResponsesFromNativeApp = {
             result:
                 | 'USER_AUTHENTICATED'
                 | 'USER_ENABLED_AUTHENTICATION'
-                | 'LAST_AUTHENTICATION_STILL_VALID';
+                | 'LAST_AUTHENTICATION_STILL_VALID'
+                | 'DEVICE_HAS_NO_AUTHENTICATION';
         };
     };
     FOCUS_NAVBAR: {


### PR DESCRIPTION
With the new PIN & Biometrics 2.0 project ([PRD](https://confluence.tid.es/pages/viewpage.action?pageId=401905341)), we rely on device authentication to secure the app instead of having a custom PIN code.

To adapt the existing method to the new implementation, I'm adding more information to the README and a new response type.