### PR TITLE
feat(setScreenName): Update setScreenName to support disable default sanitize

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,9 +630,7 @@ setScreenName: (
 ```
 
 By default, the screen name and params are sanitized (removing accents, special
-characters, lowercasing, etc). If you want to disable sanitization (for example,
-to send the screen name exactly as provided), you can pass the `sanitize: false`
-option:
+characters, lowercasing, etc). If you want to disable sanitization for the params (for example, to send them exactly as provided), you can pass the `sanitize: false` option. Note that the screen name itself will always be sanitized.
 
 ```javascript
 setScreenName('My Screen Name', {}, {sanitize: false});

--- a/README.md
+++ b/README.md
@@ -624,10 +624,13 @@ setScreenName: (
 ) => Promise<void>;
 ```
 
-By default, the screen name and params are sanitized (removing accents, special characters, lowercasing, etc). If you want to disable sanitization (for example, to send the screen name exactly as provided), you can pass the `sanitize: false` option:
+By default, the screen name and params are sanitized (removing accents, special
+characters, lowercasing, etc). If you want to disable sanitization (for example,
+to send the screen name exactly as provided), you can pass the `sanitize: false`
+option:
 
 ```javascript
-setScreenName('My Screen Name', {}, { sanitize: false });
+setScreenName('My Screen Name', {}, {sanitize: false});
 ```
 
 This will send the screen name and params as-is, without any transformation.

--- a/README.md
+++ b/README.md
@@ -630,7 +630,10 @@ setScreenName: (
 ```
 
 By default, the screen name and params are sanitized (removing accents, special
-characters, lowercasing, etc). If you want to disable sanitization for the params (for example, to send them exactly as provided), you can pass the `sanitize: false` option. Note that the screen name itself will always be sanitized.
+characters, lowercasing, etc). If you want to disable sanitization for the
+params (for example, to send them exactly as provided), you can pass the
+`sanitize: false` option. Note that the screen name itself will always be
+sanitized.
 
 ```javascript
 setScreenName('My Screen Name', {}, {sanitize: false});

--- a/README.md
+++ b/README.md
@@ -617,8 +617,20 @@ logEvent(yourEvent, {sanitize: false});
 Log the current screen name (or page name) to firebase
 
 ```ts
-setScreenName: (screenName: string, params?: {[key: string]: any}) => Promise<void>;
+setScreenName: (
+  screenName: string,
+  params?: { [key: string]: any },
+  options?: { sanitize?: boolean }
+) => Promise<void>;
 ```
+
+By default, the screen name and params are sanitized (removing accents, special characters, lowercasing, etc). If you want to disable sanitization (for example, to send the screen name exactly as provided), you can pass the `sanitize: false` option:
+
+```javascript
+setScreenName('My Screen Name', {}, { sanitize: false });
+```
+
+This will send the screen name and params as-is, without any transformation.
 
 ### setUserProperty
 

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ option:
 setScreenName('My Screen Name', {}, {sanitize: false});
 ```
 
-This will send the screen name and params as-is, without any transformation.
+This will send the params as-is, without any transformation.
 
 ### setUserProperty
 

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -387,11 +387,11 @@ test('logEvent in web is resilient to gtag script not working', async () => {
         }
     };
 
-    await expect(logEvent({ name: 'any_event' })).resolves.toBeUndefined();
+    await expect(logEvent({name: 'any_event'})).resolves.toBeUndefined();
     analyticsIsBroken = true;
-    await expect(logEvent({ name: 'any_event' })).resolves.toBeUndefined();
+    await expect(logEvent({name: 'any_event'})).resolves.toBeUndefined();
     delete (window as any).gtag;
-    await expect(logEvent({ name: 'any_event' })).resolves.toBeUndefined();
+    await expect(logEvent({name: 'any_event'})).resolves.toBeUndefined();
 });
 
 test('logEvent does not sanitize legacy events', async () => {
@@ -464,7 +464,7 @@ test('sanitizeAnalyticsParam', () => {
 
 test('sanitizeAnalyticsParams', () => {
     expect(sanitizeAnalyticsParams({})).toEqual({});
-    expect(sanitizeAnalyticsParams({ a: 'b', b: 1 })).toEqual({ a: 'b', b: 1 });
+    expect(sanitizeAnalyticsParams({a: 'b', b: 1})).toEqual({a: 'b', b: 1});
     expect(
         sanitizeAnalyticsParams({
             this_is_a_very_long_param_name_with_more_than_40_characters:

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -44,6 +44,8 @@ const origAnalyticsWebInterface = window.AnalyticsWebInterface;
 afterEach(() => {
     window.AnalyticsWebInterface = origAnalyticsWebInterface;
     window.webkit = origWebkit;
+    // Reset screen name
+    setScreenName('');
 });
 
 test('log event with default values', async () => {
@@ -385,15 +387,18 @@ test('logEvent in web is resilient to gtag script not working', async () => {
         }
     };
 
-    await expect(logEvent({name: 'any_event'})).resolves.toBeUndefined();
+    await expect(logEvent({ name: 'any_event' })).resolves.toBeUndefined();
     analyticsIsBroken = true;
-    await expect(logEvent({name: 'any_event'})).resolves.toBeUndefined();
+    await expect(logEvent({ name: 'any_event' })).resolves.toBeUndefined();
     delete (window as any).gtag;
-    await expect(logEvent({name: 'any_event'})).resolves.toBeUndefined();
+    await expect(logEvent({ name: 'any_event' })).resolves.toBeUndefined();
 });
 
 test('logEvent does not sanitize legacy events', async () => {
     const androidFirebaseMock = givenAndroidWebview();
+
+    // Set up screen name first
+    await setScreenName('any-screen-name');
 
     await logEvent({
         category: 'any category with weird characters ;!@+*',
@@ -459,7 +464,7 @@ test('sanitizeAnalyticsParam', () => {
 
 test('sanitizeAnalyticsParams', () => {
     expect(sanitizeAnalyticsParams({})).toEqual({});
-    expect(sanitizeAnalyticsParams({a: 'b', b: 1})).toEqual({a: 'b', b: 1});
+    expect(sanitizeAnalyticsParams({ a: 'b', b: 1 })).toEqual({ a: 'b', b: 1 });
     expect(
         sanitizeAnalyticsParams({
             this_is_a_very_long_param_name_with_more_than_40_characters:

--- a/src/__tests__/analytics-test.ts
+++ b/src/__tests__/analytics-test.ts
@@ -286,6 +286,23 @@ test('set screen name in iOS', async () => {
     });
 });
 
+test('setScreenName allows to turn off params sanitization', async () => {
+    const androidFirebaseMock = givenAndroidWebview();
+    const params = {
+        special_param: '*&^%$#@!',
+        another_param: 'test!@#',
+    };
+
+    await setScreenName('test-screen', params, {
+        sanitize: false,
+    });
+
+    expect(androidFirebaseMock.setScreenNameWithParams).toBeCalledWith(
+        'test-screen',
+        JSON.stringify(params),
+    );
+});
+
 test('set user property in android', async () => {
     const androidFirebaseMock = givenAndroidWebview();
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -354,27 +354,24 @@ export const setScreenName = (
     currentScreenName = screenName;
 
     const sanitizedParams = sanitize ? sanitizeAnalyticsParams(params) : params;
-    const sanitizedScreenName = sanitize
-        ? sanitizeAnalyticsParam(screenName)
-        : screenName;
 
     return withAnalytics({
         onAndroid(androidFirebase) {
             // The method to send params with the screen name is only implemented in new app versions.
             if (androidFirebase.setScreenNameWithParams) {
                 androidFirebase.setScreenNameWithParams(
-                    sanitizedScreenName,
+                    screenName,
                     JSON.stringify(sanitizedParams),
                 );
             } else if (androidFirebase.setScreenName) {
-                androidFirebase.setScreenName(sanitizedScreenName);
+                androidFirebase.setScreenName(screenName);
             }
             return Promise.resolve();
         },
         onIos(iosFirebase) {
             iosFirebase.postMessage({
                 command: 'setScreenName',
-                name: sanitizedScreenName,
+                name: screenName,
                 parameters: sanitizedParams,
             });
             return Promise.resolve();
@@ -382,8 +379,8 @@ export const setScreenName = (
         onWeb(gtag) {
             return new Promise((resolve) => {
                 gtag('event', 'page_view', {
-                    screenName: sanitizedScreenName,
-                    page_title: sanitizedScreenName,
+                    screenName,
+                    page_title: screenName,
                     previousScreenName,
                     ...sanitizedParams,
                     event_callback: createCallback(resolve),

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -349,7 +349,7 @@ export const setScreenName = (
         return Promise.resolve();
     }
 
-    const {sanitize = true} = {...defaultEventOptions, ...options};
+    const {sanitize} = {...defaultEventOptions, ...options};
     const previousScreenName = currentScreenName;
     currentScreenName = screenName;
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,4 +1,4 @@
-import { postMessageToNativeApp } from './post-message';
+import {postMessageToNativeApp} from './post-message';
 
 /** @deprecated */
 export type CustomDimensionIdx =
@@ -112,7 +112,7 @@ type FirebaseValue =
     | string
     | number
     | undefined
-    | { [key: string]: FirebaseValue }
+    | {[key: string]: FirebaseValue}
     | Array<FirebaseValue>;
 
 type FirebaseEvent = {
@@ -144,8 +144,8 @@ export const sanitizeAnalyticsParam = (str: string): string =>
 
 export const sanitizeAnalyticsParams = (params: {
     [key: string]: FirebaseValue;
-}): { [key: string]: FirebaseValue } => {
-    const sanitizedParams: { [key: string]: FirebaseValue } = {};
+}): {[key: string]: FirebaseValue} => {
+    const sanitizedParams: {[key: string]: FirebaseValue} = {};
     Object.entries(params).forEach((entry) => {
         const key = entry[0];
         const value = entry[1];
@@ -188,7 +188,7 @@ type LogEventOptions = {
     /** Whether to sanitize the event params, this only affects to FirebaseEvents. true by default. */
     sanitize?: boolean;
 };
-const defaultEventOptions = { sanitize: true };
+const defaultEventOptions = {sanitize: true};
 
 let currentScreenName = '';
 
@@ -196,8 +196,8 @@ export const logEvent = (
     event: TrackingEvent,
     options?: LogEventOptions,
 ): Promise<void> => {
-    const { sanitize } = { ...defaultEventOptions, ...options };
-    let { name, ...params } = event;
+    const {sanitize} = {...defaultEventOptions, ...options};
+    let {name, ...params} = event;
 
     // If the event doesn't have a name, it's a legacy analytics event
     if (!name) {
@@ -226,7 +226,7 @@ export const logEvent = (
     }
 
     // set screen name if not set
-    params = { ...params, screenName: params.screenName || currentScreenName };
+    params = {...params, screenName: params.screenName || currentScreenName};
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -256,10 +256,10 @@ export const logEvent = (
 
 export const logEcommerceEvent = (
     name: string,
-    params: { [key: string]: any },
+    params: {[key: string]: any},
 ): Promise<void> => {
     // set screen name if not set
-    params = { ...params, screenName: params.screenName || currentScreenName };
+    params = {...params, screenName: params.screenName || currentScreenName};
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -297,7 +297,7 @@ export const logTiming = ({
     if (!category || !variable || !value) {
         console.warn(
             'Analytics timing should have "category", "variable" and "value"',
-            { category, variable, value },
+            {category, variable, value},
         );
         return Promise.resolve();
     }
@@ -341,7 +341,7 @@ export const logTiming = ({
 
 export const setScreenName = (
     screenName: string,
-    params: { [key: string]: any } = {},
+    params: {[key: string]: any} = {},
     options?: LogEventOptions,
 ): Promise<void> => {
     if (!screenName) {
@@ -349,7 +349,7 @@ export const setScreenName = (
         return Promise.resolve();
     }
 
-    const { sanitize } = { ...defaultEventOptions, ...options };
+    const {sanitize} = {...defaultEventOptions, ...options};
     const previousScreenName = currentScreenName;
     currentScreenName = screenName;
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,4 +1,4 @@
-import {postMessageToNativeApp} from './post-message';
+import { postMessageToNativeApp } from './post-message';
 
 /** @deprecated */
 export type CustomDimensionIdx =
@@ -112,7 +112,7 @@ type FirebaseValue =
     | string
     | number
     | undefined
-    | {[key: string]: FirebaseValue}
+    | { [key: string]: FirebaseValue }
     | Array<FirebaseValue>;
 
 type FirebaseEvent = {
@@ -144,8 +144,8 @@ export const sanitizeAnalyticsParam = (str: string): string =>
 
 export const sanitizeAnalyticsParams = (params: {
     [key: string]: FirebaseValue;
-}): {[key: string]: FirebaseValue} => {
-    const sanitizedParams: {[key: string]: FirebaseValue} = {};
+}): { [key: string]: FirebaseValue } => {
+    const sanitizedParams: { [key: string]: FirebaseValue } = {};
     Object.entries(params).forEach((entry) => {
         const key = entry[0];
         const value = entry[1];
@@ -188,7 +188,7 @@ type LogEventOptions = {
     /** Whether to sanitize the event params, this only affects to FirebaseEvents. true by default. */
     sanitize?: boolean;
 };
-const defaultEventOptions = {sanitize: true};
+const defaultEventOptions = { sanitize: true };
 
 let currentScreenName = '';
 
@@ -196,8 +196,8 @@ export const logEvent = (
     event: TrackingEvent,
     options?: LogEventOptions,
 ): Promise<void> => {
-    const {sanitize} = {...defaultEventOptions, ...options};
-    let {name, ...params} = event;
+    const { sanitize } = { ...defaultEventOptions, ...options };
+    let { name, ...params } = event;
 
     // If the event doesn't have a name, it's a legacy analytics event
     if (!name) {
@@ -226,7 +226,7 @@ export const logEvent = (
     }
 
     // set screen name if not set
-    params = {...params, screenName: params.screenName || currentScreenName};
+    params = { ...params, screenName: params.screenName || currentScreenName };
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -256,10 +256,10 @@ export const logEvent = (
 
 export const logEcommerceEvent = (
     name: string,
-    params: {[key: string]: any},
+    params: { [key: string]: any },
 ): Promise<void> => {
     // set screen name if not set
-    params = {...params, screenName: params.screenName || currentScreenName};
+    params = { ...params, screenName: params.screenName || currentScreenName };
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -297,7 +297,7 @@ export const logTiming = ({
     if (!category || !variable || !value) {
         console.warn(
             'Analytics timing should have "category", "variable" and "value"',
-            {category, variable, value},
+            { category, variable, value },
         );
         return Promise.resolve();
     }
@@ -341,7 +341,7 @@ export const logTiming = ({
 
 export const setScreenName = (
     screenName: string,
-    params: {[key: string]: any} = {},
+    params: { [key: string]: any } = {},
     options?: LogEventOptions,
 ): Promise<void> => {
     if (!screenName) {
@@ -349,7 +349,7 @@ export const setScreenName = (
         return Promise.resolve();
     }
 
-    const {sanitize} = {...defaultEventOptions, ...options};
+    const { sanitize } = { ...defaultEventOptions, ...options };
     const previousScreenName = currentScreenName;
     currentScreenName = screenName;
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,4 +1,4 @@
-import { postMessageToNativeApp } from './post-message';
+import {postMessageToNativeApp} from './post-message';
 
 /** @deprecated */
 export type CustomDimensionIdx =
@@ -112,7 +112,7 @@ type FirebaseValue =
     | string
     | number
     | undefined
-    | { [key: string]: FirebaseValue }
+    | {[key: string]: FirebaseValue}
     | Array<FirebaseValue>;
 
 type FirebaseEvent = {
@@ -144,8 +144,8 @@ export const sanitizeAnalyticsParam = (str: string): string =>
 
 export const sanitizeAnalyticsParams = (params: {
     [key: string]: FirebaseValue;
-}): { [key: string]: FirebaseValue } => {
-    const sanitizedParams: { [key: string]: FirebaseValue } = {};
+}): {[key: string]: FirebaseValue} => {
+    const sanitizedParams: {[key: string]: FirebaseValue} = {};
     Object.entries(params).forEach((entry) => {
         const key = entry[0];
         const value = entry[1];
@@ -188,7 +188,7 @@ type LogEventOptions = {
     /** Whether to sanitize the event params, this only affects to FirebaseEvents. true by default. */
     sanitize?: boolean;
 };
-const defaultEventOptions = { sanitize: true };
+const defaultEventOptions = {sanitize: true};
 
 let currentScreenName = '';
 
@@ -196,8 +196,8 @@ export const logEvent = (
     event: TrackingEvent,
     options?: LogEventOptions,
 ): Promise<void> => {
-    const { sanitize } = { ...defaultEventOptions, ...options };
-    let { name, ...params } = event;
+    const {sanitize} = {...defaultEventOptions, ...options};
+    let {name, ...params} = event;
 
     // If the event doesn't have a name, it's a legacy analytics event
     if (!name) {
@@ -226,7 +226,7 @@ export const logEvent = (
     }
 
     // set screen name if not set
-    params = { ...params, screenName: params.screenName || currentScreenName };
+    params = {...params, screenName: params.screenName || currentScreenName};
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -256,10 +256,10 @@ export const logEvent = (
 
 export const logEcommerceEvent = (
     name: string,
-    params: { [key: string]: any },
+    params: {[key: string]: any},
 ): Promise<void> => {
     // set screen name if not set
-    params = { ...params, screenName: params.screenName || currentScreenName };
+    params = {...params, screenName: params.screenName || currentScreenName};
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -297,7 +297,7 @@ export const logTiming = ({
     if (!category || !variable || !value) {
         console.warn(
             'Analytics timing should have "category", "variable" and "value"',
-            { category, variable, value },
+            {category, variable, value},
         );
         return Promise.resolve();
     }
@@ -341,7 +341,7 @@ export const logTiming = ({
 
 export const setScreenName = (
     screenName: string,
-    params: { [key: string]: any } = {},
+    params: {[key: string]: any} = {},
     options?: LogEventOptions,
 ): Promise<void> => {
     if (!screenName) {
@@ -349,12 +349,14 @@ export const setScreenName = (
         return Promise.resolve();
     }
 
-    const { sanitize = true } = { ...defaultEventOptions, ...options };
+    const {sanitize = true} = {...defaultEventOptions, ...options};
     const previousScreenName = currentScreenName;
     currentScreenName = screenName;
 
     const sanitizedParams = sanitize ? sanitizeAnalyticsParams(params) : params;
-    const sanitizedScreenName = sanitize ? sanitizeAnalyticsParam(screenName) : screenName;
+    const sanitizedScreenName = sanitize
+        ? sanitizeAnalyticsParam(screenName)
+        : screenName;
 
     return withAnalytics({
         onAndroid(androidFirebase) {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,4 +1,4 @@
-import {postMessageToNativeApp} from './post-message';
+import { postMessageToNativeApp } from './post-message';
 
 /** @deprecated */
 export type CustomDimensionIdx =
@@ -112,7 +112,7 @@ type FirebaseValue =
     | string
     | number
     | undefined
-    | {[key: string]: FirebaseValue}
+    | { [key: string]: FirebaseValue }
     | Array<FirebaseValue>;
 
 type FirebaseEvent = {
@@ -144,8 +144,8 @@ export const sanitizeAnalyticsParam = (str: string): string =>
 
 export const sanitizeAnalyticsParams = (params: {
     [key: string]: FirebaseValue;
-}): {[key: string]: FirebaseValue} => {
-    const sanitizedParams: {[key: string]: FirebaseValue} = {};
+}): { [key: string]: FirebaseValue } => {
+    const sanitizedParams: { [key: string]: FirebaseValue } = {};
     Object.entries(params).forEach((entry) => {
         const key = entry[0];
         const value = entry[1];
@@ -188,7 +188,7 @@ type LogEventOptions = {
     /** Whether to sanitize the event params, this only affects to FirebaseEvents. true by default. */
     sanitize?: boolean;
 };
-const defaultEventOptions = {sanitize: true};
+const defaultEventOptions = { sanitize: true };
 
 let currentScreenName = '';
 
@@ -196,8 +196,8 @@ export const logEvent = (
     event: TrackingEvent,
     options?: LogEventOptions,
 ): Promise<void> => {
-    const {sanitize} = {...defaultEventOptions, ...options};
-    let {name, ...params} = event;
+    const { sanitize } = { ...defaultEventOptions, ...options };
+    let { name, ...params } = event;
 
     // If the event doesn't have a name, it's a legacy analytics event
     if (!name) {
@@ -226,7 +226,7 @@ export const logEvent = (
     }
 
     // set screen name if not set
-    params = {...params, screenName: params.screenName || currentScreenName};
+    params = { ...params, screenName: params.screenName || currentScreenName };
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -256,10 +256,10 @@ export const logEvent = (
 
 export const logEcommerceEvent = (
     name: string,
-    params: {[key: string]: any},
+    params: { [key: string]: any },
 ): Promise<void> => {
     // set screen name if not set
-    params = {...params, screenName: params.screenName || currentScreenName};
+    params = { ...params, screenName: params.screenName || currentScreenName };
 
     return withAnalytics({
         onAndroid(androidFirebase) {
@@ -297,7 +297,7 @@ export const logTiming = ({
     if (!category || !variable || !value) {
         console.warn(
             'Analytics timing should have "category", "variable" and "value"',
-            {category, variable, value},
+            { category, variable, value },
         );
         return Promise.resolve();
     }
@@ -341,44 +341,49 @@ export const logTiming = ({
 
 export const setScreenName = (
     screenName: string,
-    params: {[key: string]: any} = {},
+    params: { [key: string]: any } = {},
+    options?: LogEventOptions,
 ): Promise<void> => {
     if (!screenName) {
         console.warn('Missing analytics screenName');
         return Promise.resolve();
     }
 
+    const { sanitize = true } = { ...defaultEventOptions, ...options };
     const previousScreenName = currentScreenName;
     currentScreenName = screenName;
+
+    const sanitizedParams = sanitize ? sanitizeAnalyticsParams(params) : params;
+    const sanitizedScreenName = sanitize ? sanitizeAnalyticsParam(screenName) : screenName;
 
     return withAnalytics({
         onAndroid(androidFirebase) {
             // The method to send params with the screen name is only implemented in new app versions.
             if (androidFirebase.setScreenNameWithParams) {
                 androidFirebase.setScreenNameWithParams(
-                    screenName,
-                    JSON.stringify(sanitizeAnalyticsParams(params)),
+                    sanitizedScreenName,
+                    JSON.stringify(sanitizedParams),
                 );
             } else if (androidFirebase.setScreenName) {
-                androidFirebase.setScreenName(screenName);
+                androidFirebase.setScreenName(sanitizedScreenName);
             }
             return Promise.resolve();
         },
         onIos(iosFirebase) {
             iosFirebase.postMessage({
                 command: 'setScreenName',
-                name: screenName,
-                parameters: sanitizeAnalyticsParams(params),
+                name: sanitizedScreenName,
+                parameters: sanitizedParams,
             });
             return Promise.resolve();
         },
         onWeb(gtag) {
             return new Promise((resolve) => {
                 gtag('event', 'page_view', {
-                    screenName,
-                    page_title: screenName,
+                    screenName: sanitizedScreenName,
+                    page_title: sanitizedScreenName,
                     previousScreenName,
-                    ...sanitizeAnalyticsParams(params),
+                    ...sanitizedParams,
                     event_callback: createCallback(resolve),
                 });
             });


### PR DESCRIPTION
https://jira.tid.es/browse/WEB-2242

This PR adds the ability to optionally disable sanitization in setScreenName function, similar to how logEvent works.

By default, it maintains the current behavior (sanitization enabled), but now allows disabling it via an options parameter.

Examples of usage:

// Default behavior (with sanitization)
setScreenName(\"Your Screen Name\");

// With params (sanitized)
setScreenName(\"Your Screen Name\", {param1: \"value1\"});

// With sanitization explicitly disabled
setScreenName(\"Your Screen Name\", {param1: \"value1\"}, {sanitize: false});
