### PR TITLE
Clarify documentation according to API level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1896,7 +1896,10 @@ requestPermissionBackgroundLocation: () => Promise<{
 
 #### Notes
 
--   Android: On Android 9 and below, background access is granted with foreground location. While Android 10 and above foreground location is requested first, if not granted, followed by background.
+-   Android:
+    - Android 9 and below, background access is granted with foreground location
+    - While Android 10 and above foreground location is requested first,
+    if not granted, followed by background.
 -   iOS: upgrade to Always happens via OS escalation after background usage.
 
 #### Error cases

--- a/README.md
+++ b/README.md
@@ -1896,7 +1896,9 @@ requestPermissionBackgroundLocation: () => Promise<{
 
 #### Notes
 
--   Android: this method navigates to OS settings.
+-   Android:
+    - On Android 9 and below, background access is granted with foreground location
+    - Android 10 and above foreground location is requested first, if not granted, followed by background.
 -   iOS: upgrade to Always happens via OS escalation after background usage.
 
 #### Error cases

--- a/README.md
+++ b/README.md
@@ -1896,9 +1896,11 @@ requestPermissionBackgroundLocation: () => Promise<{
 
 #### Notes
 
--   Android: Android 9 and below, background access is granted with foreground
-    location. While Android 10 and above foreground location is requested
-    first, if not granted, followed by background.
+-   Android:
+    -   Android 9 and below, background access is granted with foreground
+        location.
+    -   Android 10 and above foreground location is requested first, if not
+        granted, followed by background.
 -   iOS: upgrade to Always happens via OS escalation after background usage.
 
 #### Error cases

--- a/README.md
+++ b/README.md
@@ -1896,11 +1896,9 @@ requestPermissionBackgroundLocation: () => Promise<{
 
 #### Notes
 
--   Android:
-    -   Android 9 and below, background access is granted with foreground
-    location
-    -   While Android 10 and above foreground location is requested first,
-    if not granted, followed by background.
+-   Android: Android 9 and below, background access is granted with foreground
+    location. While Android 10 and above foreground location is requested
+    first, if not granted, followed by background.
 -   iOS: upgrade to Always happens via OS escalation after background usage.
 
 #### Error cases

--- a/README.md
+++ b/README.md
@@ -1896,9 +1896,7 @@ requestPermissionBackgroundLocation: () => Promise<{
 
 #### Notes
 
--   Android:
-    - On Android 9 and below, background access is granted with foreground location
-    - Android 10 and above foreground location is requested first, if not granted, followed by background.
+-   Android: On Android 9 and below, background access is granted with foreground location. While Android 10 and above foreground location is requested first, if not granted, followed by background.
 -   iOS: upgrade to Always happens via OS escalation after background usage.
 
 #### Error cases

--- a/README.md
+++ b/README.md
@@ -1897,8 +1897,9 @@ requestPermissionBackgroundLocation: () => Promise<{
 #### Notes
 
 -   Android:
-    - Android 9 and below, background access is granted with foreground location
-    - While Android 10 and above foreground location is requested first,
+    -   Android 9 and below, background access is granted with foreground
+    location
+    -   While Android 10 and above foreground location is requested first,
     if not granted, followed by background.
 -   iOS: upgrade to Always happens via OS escalation after background usage.
 


### PR DESCRIPTION
We need to clarify a variation in requestPermissionBackgroundLocation for Android depending on the API we are using.

